### PR TITLE
Fixes for Setup

### DIFF
--- a/Budget__c-Expense__c.json
+++ b/Budget__c-Expense__c.json
@@ -1,0 +1,46 @@
+{
+    "records": [
+        {
+            "attributes": {
+                "type": "Budget__c",
+                "referenceId": "Budget__cRef1"
+            },
+            "Name": "October Budget",
+            "Month__c": "October",
+            "Expenses__r": {
+                "records": [
+                    {
+                        "attributes": {
+                            "type": "Expense__c",
+                            "referenceId": "Expense__cRef1"
+                        },
+                        "Amount__c": 85.44,
+                        "Name": "Halloween costume",
+                        "Transaction_Category__c": "Shopping",
+                        "Transaction_Date__c": "2024-10-19"
+                    },
+                    {
+                        "attributes": {
+                            "type": "Expense__c",
+                            "referenceId": "Expense__cRef2"
+                        },
+                        "Amount__c": 43.22,
+                        "Name": "Halloween candy",
+                        "Transaction_Category__c": "Groceries",
+                        "Transaction_Date__c": "2024-10-21"
+                    },
+                    {
+                        "attributes": {
+                            "type": "Expense__c",
+                            "referenceId": "Expense__cRef3"
+                        },
+                        "Amount__c": 5.5,
+                        "Name": "RTD Day Pass",
+                        "Transaction_Category__c": "Vehicle",
+                        "Transaction_Date__c": "2024-10-22"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -3,23 +3,15 @@
 Inflation and its effects have you in a tizzy! You recently got a higher than normal water bill and you screamed at the mail man. You think to yourself that you wish you had a way to track your expenses so that you can create more visibility into what you are spending. Being proficient in Salesforce as a developer, you decide to build an expense tracker Lightning Web Component that allows you to enter and track your expenses. 
 
 ## Setup Steps
-- If you are planning on cloning the repo from Github -> Clone the repository from github into VS Code using the following command in your terminal
-    - git clone https://github.com/taylor-ortiz/denver-dev-expense-tracker-lwc.git
-- If you do not have github and do not have git -> Find the file in the public github repo called "denver-dev-expense-tracker-lwc"
-    - Click on it
-    - Select "View Raw" (this should auto download it)
-    - Open this folder in VS Code
-- If you have not already "Authorized an Org" in your VS Code environment, please do so
-- Once authorized, navigate to force-app/main/default, right click, and select "SFDX: Deploy This Source To Org"
-- We will do a cursory look here to make sure everything made it in okay
-- Once confirmed, lets use either the UI in Salesforce or the CLI to create a Budget__c record
-    - If creating in the UI, navigate in the 'Expense Tracker' app to the Budget tab, select New and fill in the following attributes:
-        - Name: 'October Budget'
-        - Month: 'October'
-    - If creating using the CLI, just navigate to your terminal and run the following command:
-        - sfdx force:data:record:create -s Budget__c -v "Name='October Budget' Month__c='October'" --json
-- Once we have created the Budget__c record, we can go ahead and create some Expense records in the UI under the Budget__c record you just created so we have something show up in the list view when we load the component on the Home page
-
+1. **Clone the Repo:** Clone the repository from github by using git clone or downloading the zip file
+    - Open the terminal and go to a folder you want to store code in and run the following command: ```git clone https://github.com/taylor-ortiz/denver-dev-expense-tracker-lwc.git```
+    - If you do not have github and do not have git -> download this zip file "[denver-dev-expense-tracker-lwc.zip](https://github.com/taylor-ortiz/denver-dev-expense-tracker-lwc/raw/refs/heads/main/denver-dev-expense-tracker-lwc.zip)" and extract the contents.
+    - Then, regardless of the method you used, open the denver-dev-expense-tracker-lwc folder in VS Code.
+1. **Authorize your dev org:** If you have not already "Authorized an Org" in your VS Code environment, click "No Default Org Set" in the VS Code Status bar (bottom bar) and authorize your dev org.
+    - If you don't have a dev org, you can create a scratch org by running ```sf org create scratch -d -f config/project-scratch-def.json -a expense-tracker-lwc```
+1. **Deploy the repo:** Once authorized, navigate to force-app/main/default, right click, and select "SFDX: Deploy This Source To Org"
+1. **Create some test records:** Now let's create a budget for October and some test records. You can go to the Expense Tracker app and create them yourself, or import our example data using the following command.
+    - ```sf data import tree --files Budget__c-Expense__c.json```
 
 ## Here is what we will be building
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Inflation and its effects have you in a tizzy! You recently got a higher than no
 1. **Authorize your dev org:** If you have not already "Authorized an Org" in your VS Code environment, click "No Default Org Set" in the VS Code Status bar (bottom bar) and authorize your dev org.
     - If you don't have a dev org, you can create a scratch org by running ```sf org create scratch -d -f config/project-scratch-def.json -a expense-tracker-lwc```
 1. **Deploy the repo:** Once authorized, navigate to force-app/main/default, right click, and select "SFDX: Deploy This Source To Org"
+1. **Assign the Expense Tracker permissions:** Give your user the Expense Tracker permission set via setup or by running the following command:
+    - ```sf org assign permset --name Expense_Tracker```
 1. **Create some test records:** Now let's create a budget for October and some test records. You can go to the Expense Tracker app and create them yourself, or import our example data using the following command.
     - ```sf data import tree --files Budget__c-Expense__c.json```
 

--- a/force-app/main/default/layouts/Budget__c-Budget Layout.layout-meta.xml
+++ b/force-app/main/default/layouts/Budget__c-Budget Layout.layout-meta.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Layout xmlns="http://soap.sforce.com/2006/04/metadata">
+    <excludeButtons>OpenSlackRecordChannel</excludeButtons>
     <layoutSections>
         <customLabel>false</customLabel>
         <detailHeading>false</detailHeading>
@@ -57,7 +58,12 @@
     </layoutSections>
     <relatedLists>
         <fields>NAME</fields>
+        <fields>Amount__c</fields>
+        <fields>Transaction_Date__c</fields>
+        <fields>Transaction_Category__c</fields>
         <relatedList>Expense__c.Budget__c</relatedList>
+        <sortField>Transaction_Date__c</sortField>
+        <sortOrder>Desc</sortOrder>
     </relatedLists>
     <showEmailCheckbox>false</showEmailCheckbox>
     <showHighlightsPanel>false</showHighlightsPanel>

--- a/force-app/main/default/objects/Expense__c/fields/Amount__c.field-meta.xml
+++ b/force-app/main/default/objects/Expense__c/fields/Amount__c.field-meta.xml
@@ -4,7 +4,7 @@
     <label>Amount</label>
     <precision>18</precision>
     <required>true</required>
-    <scale>0</scale>
+    <scale>2</scale>
     <trackTrending>false</trackTrending>
     <type>Currency</type>
 </CustomField>

--- a/force-app/main/default/permissionsets/Expense_Tracker.permissionset-meta.xml
+++ b/force-app/main/default/permissionsets/Expense_Tracker.permissionset-meta.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<PermissionSet xmlns="http://soap.sforce.com/2006/04/metadata">
+    <applicationVisibilities>
+        <application>Expense_Tracker</application>
+        <visible>true</visible>
+    </applicationVisibilities>
+    <fieldPermissions>
+        <editable>false</editable>
+        <field>Budget__c.Total__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <fieldPermissions>
+        <editable>true</editable>
+        <field>Expense__c.Month__c</field>
+        <readable>true</readable>
+    </fieldPermissions>
+    <hasActivationRequired>false</hasActivationRequired>
+    <label>Expense Tracker</label>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>Budget__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <objectPermissions>
+        <allowCreate>false</allowCreate>
+        <allowDelete>true</allowDelete>
+        <allowEdit>true</allowEdit>
+        <allowRead>true</allowRead>
+        <modifyAllRecords>true</modifyAllRecords>
+        <object>Expense__c</object>
+        <viewAllRecords>true</viewAllRecords>
+    </objectPermissions>
+    <tabSettings>
+        <tab>Budget__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+    <tabSettings>
+        <tab>Expense__c</tab>
+        <visibility>Visible</visibility>
+    </tabSettings>
+</PermissionSet>


### PR DESCRIPTION
### Fixed:

1. Added a permission set because the app and tabs weren't visible by default
2. Updated the Budget page layout so you can see more details about the expenses
3. Updated the Amount field on Expense to have two decimal places like the LWC screenshot
4. Added example records that can be imported quickly
5. Updated the readme with the above changes

### Not Fixed:

1. Currently you can't deploy this to a new scratch org because the logo for the app is not in the repo. Either need to add the logo or remove the <brand> element in the app definition. 